### PR TITLE
Synthetic cdr examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ problem with you local Spark installation.
 To get it running in a local spark-shell use the command
 
 ``` shell
-spark-shell --jars target/scala-2.11/co-traj_2.11-1.0.jar --packages com.graphhopper:map-matching:0.7.0,io.spray:spray-json_2.11:1.3.5
+spark-shell --jars target/scala-2.11/co-traj_2.11-1.0.jar --packages com.graphhopper:map-matching:0.7.0,io.spray:spray-json_2.11:1.3.5,org.locationtech.geotrellis:geotrellis-gdal_2.12:3.3.0
 ```
 
 You should then be able to run the first example

--- a/build.sbt
+++ b/build.sbt
@@ -11,3 +11,4 @@ sparkComponents += "graphx"
 libraryDependencies += "io.spray" %% "spray-json" % "1.3.5"
 libraryDependencies += "com.graphhopper" % "map-matching" % "0.7.0"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % Test
+libraryDependencies += "org.locationtech.geotrellis" %% "geotrellis-gdal" % "3.3.0"

--- a/src/main/scala/ExampleSynthCDR.scala
+++ b/src/main/scala/ExampleSynthCDR.scala
@@ -1,0 +1,98 @@
+import CoTrajectoryUtils._
+import Swapmob._
+import org.apache.spark.sql.Dataset
+import org.apache.spark.graphx._
+import java.io._
+import scala.collection.JavaConversions._
+
+object ExampleSynthCDR {
+  
+  val spark = SparkSessionHolder.spark
+  import spark.implicits._
+
+  def runExample() = {
+    /* Open file for normal output */
+    val output = new PrintWriter(new File("output/synthetic-cdr-test.txt"))
+
+    /* Parse the co-trajectory */
+    val cotraj: Dataset[Trajectory] = Parse
+      .syntheticCDR("data/examples/cdr-synthetic-antennas.csv")
+      .cache
+
+    /* Compute number of trajectories and number of measurements */
+    val numTrajectories: Long = cotraj.count
+    val numMeasurements: Long = cotraj.map(_.measurements.length).reduce(_ + _)
+
+    output.println("Number of trajectories: " + numTrajectories.toString)
+    println("Number of trajectories: " + numTrajectories.toString)
+
+    output.println("Number of measurements: " + numMeasurements.toString)
+    println("Number of measurements: " + numMeasurements.toString)
+
+    /* Compute possible swaps */ 
+    val partitioning: (Long, Double) = (60L * 5, 1000L)
+    val swaps: Dataset[Swap] = cotraj
+      .map(_.partitionDistinct(partitioning))
+      .swaps(partitioning._1)
+      .cache
+
+    val numSwaps: Long = swaps.count
+
+    output.println("Number of possible swaps: " + numSwaps.toString)
+    println("Number of possible swaps: " + numSwaps.toString)
+    output.close()
+        
+    numTrajectories
+  }
+
+  
+  def runGridSizeTimeTest() = {
+    /* Open file for normal output */
+    val output = new PrintWriter(new File("output/synthetic-cdr-grid-size-time.txt"))
+
+    /* Parse the co-trajectory */
+    val cotraj: Dataset[Trajectory] = Parse
+      .syntheticCDR("data/examples/cdr-synthetic-antennas.csv")
+      .cache
+
+    /* Compute number of trajectories and number of measurements */
+    val numTrajectories: Long = cotraj.count
+    val numMeasurements: Long = cotraj.map(_.measurements.length).reduce(_ + _)
+
+    output.println("Number of trajectories: " + numTrajectories.toString)
+    println("Number of trajectories: " + numTrajectories.toString)
+
+    output.println("Number of measurements: " + numMeasurements.toString)
+    println("Number of measurements: " + numMeasurements.toString)
+
+    /* Compute possible swaps for different values of grid's size 
+     * and time step. 
+     * Chosen values approximately correspond to the sequence used 
+     * in (Salas et al., 2020), but transformed to meters
+     */ 
+    output.println("Number of possible swaps for different grid size and time step")
+    println("Number of possible swaps for different grid size and time step")
+
+    output.println("Time step\tGrid size\tNumber of swaps")
+    println("Time step\tGrid size\tNumber of swaps")
+
+    for(timeStep <- Seq(5, 10, 15, 20, 25)) 
+      for(gridSize <- Seq(111, 55, 27, 11, 8.3, 5.5, 1.11, 0.555)) {
+        val partitioning: (Long, Double) = (60L * timeStep, 1000L * gridSize)
+        
+        val swaps: Dataset[Swap] = cotraj
+          .map(_.partitionDistinct(partitioning))
+          .swaps(partitioning._1)
+          .cache
+
+        val numSwaps: Long = swaps.count
+
+        output.println(Seq(timeStep, gridSize, numSwaps).mkString("\t"))
+        println(Seq(timeStep, gridSize, numSwaps).mkString("\t"))
+    }
+    
+    output.close()
+
+    numMeasurements
+  }
+}

--- a/src/main/scala/ExampleSynthCDRLatLng.scala
+++ b/src/main/scala/ExampleSynthCDRLatLng.scala
@@ -1,0 +1,96 @@
+import CoTrajectoryUtils._
+import Swapmob._
+import org.apache.spark.sql.Dataset
+import org.apache.spark.graphx._
+import java.io._
+import scala.collection.JavaConversions._
+
+object ExampleSynthCDRLatLng {
+  
+  val spark = SparkSessionHolder.spark
+  import spark.implicits._
+
+  def runExample() = {
+    /* Open file for normal output */
+    val output = new PrintWriter(new File("output/synthetic-cdr-test-latlng.txt"))
+
+    /* Parse the co-trajectory */
+    val cotraj: Dataset[Trajectory] = Parse
+      .syntheticCDR("data/examples/cdr-synthetic-antennas.csv")
+      .cache
+
+    /* Compute number of trajectories and number of measurements */
+    val numTrajectories: Long = cotraj.count
+    val numMeasurements: Long = cotraj.map(_.measurements.length).reduce(_ + _)
+
+    output.println("Number of trajectories: " + numTrajectories.toString)
+    println("Number of trajectories: " + numTrajectories.toString)
+
+    output.println("Number of measurements: " + numMeasurements.toString)
+    println("Number of measurements: " + numMeasurements.toString)
+
+    /* Compute possible swaps */ 
+    val partitioning: (Long, Double) = (60L * 5, 1000L)
+    val swaps: Dataset[Swap] = cotraj
+      .map(_.partitionDistinct(partitioning))
+      .swaps(partitioning._1)
+      .cache
+
+    val numSwaps: Long = swaps.count
+
+    output.println("Number of possible swaps: " + numSwaps.toString)
+    println("Number of possible swaps: " + numSwaps.toString)
+    output.close()
+        
+    numTrajectories
+  }
+
+  
+  def runGridSizeTimeTest() = {
+    /* Open file for normal output */
+    val output = new PrintWriter(new File("output/synthetic-cdr-grid-size-time-latlng.txt"))
+
+    /* Parse the co-trajectory */
+    val cotraj: Dataset[Trajectory] = Parse
+      .syntheticCDR("data/examples/cdr-synthetic-antennas.csv")
+      .cache
+
+    /* Compute number of trajectories and number of measurements */
+    val numTrajectories: Long = cotraj.count
+    val numMeasurements: Long = cotraj.map(_.measurements.length).reduce(_ + _)
+
+    output.println("Number of trajectories: " + numTrajectories.toString)
+    println("Number of trajectories: " + numTrajectories.toString)
+
+    output.println("Number of measurements: " + numMeasurements.toString)
+    println("Number of measurements: " + numMeasurements.toString)
+
+    /* Compute possible swaps for different values of grid's size (degrees) 
+     * and time step (seconds)
+     */ 
+    output.println("Number of possible swaps for different grid size and time step")
+    println("Number of possible swaps for different grid size and time step")
+
+    output.println("Time step\tGrid size\tNumber of swaps")
+    println("Time step\tGrid size\tNumber of swaps")
+
+    for(timeStep <- Seq(5, 10, 15, 20, 25)) 
+      for(gridSize <- Seq(1, 0.5, 0.25, 0.1, 0.075, 0.05, 0.01, 0.005)) {
+        val partitioning: (Long, Double) = (60L * timeStep, gridSize)
+        
+        val swaps: Dataset[Swap] = cotraj
+          .map(_.partitionDistinct(partitioning))
+          .swaps(partitioning._1)
+          .cache
+
+        val numSwaps: Long = swaps.count
+
+        output.println(Seq(timeStep, gridSize, numSwaps).mkString("\t"))
+        println(Seq(timeStep, gridSize, numSwaps).mkString("\t"))
+    }
+    
+    output.close()
+
+    numMeasurements
+  }
+}

--- a/src/test/scala/ExampleSynthCDRLatLngTest.scala
+++ b/src/test/scala/ExampleSynthCDRLatLngTest.scala
@@ -1,0 +1,19 @@
+import CoTrajectoryUtils._
+import Swapmob._
+import org.apache.spark.sql.Dataset
+import org.apache.spark.graphx._
+import java.io._
+import scala.collection.JavaConversions._
+
+class ExampleSynthCDRLatLngTest extends org.scalatest.FunSuite {
+  
+  test("ExampleSynthCDRLatLng.runExample") {
+    val numTrajectories = ExampleSynthCDRLatLng.runExample
+    assert(numTrajectories == 18496)
+  }
+  
+  test("ExampleSynthCDRLatLng.runGridSizeTimeTest") {
+    val numMeasurements = ExampleSynthCDRLatLng.runGridSizeTimeTest
+    assert(numMeasurements == 242217)
+  }
+}

--- a/src/test/scala/ExampleSynthCDRTest.scala
+++ b/src/test/scala/ExampleSynthCDRTest.scala
@@ -1,0 +1,19 @@
+import CoTrajectoryUtils._
+import Swapmob._
+import org.apache.spark.sql.Dataset
+import org.apache.spark.graphx._
+import java.io._
+import scala.collection.JavaConversions._
+
+class ExampleSynthCDRTest extends org.scalatest.FunSuite {
+  
+  test("ExampleSynthCDR.runExample") {
+    val numTrajectories = ExampleSynthCDR.runExample
+    assert(numTrajectories == 18496)
+  }
+  
+  test("ExampleSynthCDR.runGridSizeTimeTest") {
+    val numMeasurements = ExampleSynthCDR.runGridSizeTimeTest
+    assert(numMeasurements == 242217)
+  }
+}


### PR DESCRIPTION
I created 2 examples of applying SwapMob algorithm to synthetic CDRs (Call Detail Record) dataset. 
One example uses original coordinate system (ITM), another one transforms location to the longitude/latitude coordinates (transformation is performed using geotrellis-gdal).
Each example runs SwapMob for the same set of parameters, changing time partition and grid size.

Strangly, outputs of examples are very different.